### PR TITLE
fix: remove account-map dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,5 +31,5 @@
 - CI: ensure pre-commit, TFLint, and tests pass. Avoid unrelated changes in the same PR.
 
 ## Security & Configuration Tips
-- Never commit secrets. Configure AWS credentials/role assumption externally; the provider setup in `src/providers.tf` supports role assumption via the `iam_roles` module.
+- Never commit secrets. Configure AWS credentials/role assumption externally; the providers use ambient credentials supplied by the execution environment.
 - Global quotas must be applied in `us-east-1`; place in the `gbl` stack and set `region: us-east-1` in `vars`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ This component provisions infrastructure to serve a Single Page Application (SPA
 
 NOTE: The component does not use the ACM created by `dns-delegated`, because the ACM region has to be `us-east-1`.
 
+Configure AWS credentials and role assumption in the runner or surrounding execution environment. The component providers use ambient credentials.
+
 
 > [!TIP]
 > #### 👽 Use Atmos with Terraform
@@ -194,21 +196,21 @@ components:
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
 | <a name="provider_aws.failover"></a> [aws.failover](#provider\_aws.failover) | >= 4.9.0, < 6.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
@@ -224,7 +226,7 @@ components:
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudfront_cache_policy.created_cache_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_origin_request_policy.created_origin_request_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_iam_policy.additional_lambda_edge_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -232,13 +234,14 @@ components:
 | [aws_iam_role_policy_attachment.additional_lambda_edge_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_shield_protection.shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_iam_policy_document.additional_lambda_edge_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.github_actions_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.github_actions_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_s3_bucket.failover_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_block_origin_public_access_enabled"></a> [block\_origin\_public\_access\_enabled](#input\_block\_origin\_public\_access\_enabled) | When set to 'true' the s3 origin bucket will have public access block enabled. | `bool` | `true` | no |
@@ -328,7 +331,7 @@ components:
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cloudfront_distribution_alias"></a> [cloudfront\_distribution\_alias](#output\_cloudfront\_distribution\_alias) | Cloudfront Distribution Alias Record. |
 | <a name="output_cloudfront_distribution_domain_name"></a> [cloudfront\_distribution\_domain\_name](#output\_cloudfront\_distribution\_domain\_name) | Cloudfront Distribution Domain Name. |
 | <a name="output_cloudfront_distribution_identity_arn"></a> [cloudfront\_distribution\_identity\_arn](#output\_cloudfront\_distribution\_identity\_arn) | CloudFront Distribution Origin Access Identity IAM ARN. |

--- a/README.md
+++ b/README.md
@@ -211,10 +211,9 @@ components:
 |------|--------|---------|
 | <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_gha_assume_role"></a> [gha\_assume\_role](#module\_gha\_assume\_role) | ../account-map/modules/team-assume-role-policy | n/a |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
+| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_lambda_edge"></a> [lambda\_edge](#module\_lambda\_edge) | cloudposse/cloudfront-s3-cdn/aws//modules/lambda@edge | 1.1.1 |
 | <a name="module_lambda_edge_functions"></a> [lambda\_edge\_functions](#module\_lambda\_edge\_functions) | cloudposse/config/yaml//modules/deepmerge | 1.0.2 |
 | <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 1.1.1 |

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ components:
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 2.0.0, < 3.0.0 |
 
 ## Providers
 
@@ -212,16 +213,16 @@ components:
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
-| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
-| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
+| <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_lambda_edge"></a> [lambda\_edge](#module\_lambda\_edge) | cloudposse/cloudfront-s3-cdn/aws//modules/lambda@edge | 1.1.1 |
 | <a name="module_lambda_edge_functions"></a> [lambda\_edge\_functions](#module\_lambda\_edge\_functions) | cloudposse/config/yaml//modules/deepmerge | 1.0.2 |
 | <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 1.1.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.4.0 |
-| <a name="module_waf"></a> [waf](#module\_waf) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_waf"></a> [waf](#module\_waf) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ components:
 | <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
-| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
+| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_lambda_edge"></a> [lambda\_edge](#module\_lambda\_edge) | cloudposse/cloudfront-s3-cdn/aws//modules/lambda@edge | 1.1.1 |
 | <a name="module_lambda_edge_functions"></a> [lambda\_edge\_functions](#module\_lambda\_edge\_functions) | cloudposse/config/yaml//modules/deepmerge | 1.0.2 |

--- a/README.yaml
+++ b/README.yaml
@@ -11,6 +11,8 @@ description: |-
 
   NOTE: The component does not use the ACM created by `dns-delegated`, because the ACM region has to be `us-east-1`.
 
+  Configure AWS credentials and role assumption in the runner or surrounding execution environment. The component providers use ambient credentials.
+
 usage: |-
   **Stack Level**: Regional
 

--- a/src/README.md
+++ b/src/README.md
@@ -162,7 +162,7 @@ components:
 | <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
-| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
+| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_lambda_edge"></a> [lambda\_edge](#module\_lambda\_edge) | cloudposse/cloudfront-s3-cdn/aws//modules/lambda@edge | 1.1.1 |
 | <a name="module_lambda_edge_functions"></a> [lambda\_edge\_functions](#module\_lambda\_edge\_functions) | cloudposse/config/yaml//modules/deepmerge | 1.0.2 |

--- a/src/README.md
+++ b/src/README.md
@@ -14,6 +14,8 @@ This component provisions infrastructure to serve a Single Page Application (SPA
 - ACM certificate issued in `us-east-1` (required by CloudFront)
 
 NOTE: The component does not use the ACM created by `dns-delegated`, because the ACM region has to be `us-east-1`.
+
+Configure AWS credentials and role assumption in the runner or surrounding execution environment. The component providers use ambient credentials.
 ## Usage
 
 **Stack Level**: Regional
@@ -142,21 +144,21 @@ components:
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0, < 6.0.0 |
 | <a name="provider_aws.failover"></a> [aws.failover](#provider\_aws.failover) | >= 4.9.0, < 6.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
@@ -172,7 +174,7 @@ components:
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudfront_cache_policy.created_cache_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_origin_request_policy.created_origin_request_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_iam_policy.additional_lambda_edge_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -180,13 +182,14 @@ components:
 | [aws_iam_role_policy_attachment.additional_lambda_edge_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_shield_protection.shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_iam_policy_document.additional_lambda_edge_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.github_actions_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.github_actions_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_s3_bucket.failover_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_attributes"></a> [attributes](#input\_attributes) | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,<br/>in the order they appear in the list. New attributes are appended to the<br/>end of the list. The elements of the list are joined by the `delimiter`<br/>and treated as a single ID element. | `list(string)` | `[]` | no |
 | <a name="input_block_origin_public_access_enabled"></a> [block\_origin\_public\_access\_enabled](#input\_block\_origin\_public\_access\_enabled) | When set to 'true' the s3 origin bucket will have public access block enabled. | `bool` | `true` | no |
@@ -276,7 +279,7 @@ components:
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_cloudfront_distribution_alias"></a> [cloudfront\_distribution\_alias](#output\_cloudfront\_distribution\_alias) | Cloudfront Distribution Alias Record. |
 | <a name="output_cloudfront_distribution_domain_name"></a> [cloudfront\_distribution\_domain\_name](#output\_cloudfront\_distribution\_domain\_name) | Cloudfront Distribution Domain Name. |
 | <a name="output_cloudfront_distribution_identity_arn"></a> [cloudfront\_distribution\_identity\_arn](#output\_cloudfront\_distribution\_identity\_arn) | CloudFront Distribution Origin Access Identity IAM ARN. |

--- a/src/README.md
+++ b/src/README.md
@@ -159,10 +159,9 @@ components:
 |------|--------|---------|
 | <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
 | <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_gha_assume_role"></a> [gha\_assume\_role](#module\_gha\_assume\_role) | ../account-map/modules/team-assume-role-policy | n/a |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
+| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_lambda_edge"></a> [lambda\_edge](#module\_lambda\_edge) | cloudposse/cloudfront-s3-cdn/aws//modules/lambda@edge | 1.1.1 |
 | <a name="module_lambda_edge_functions"></a> [lambda\_edge\_functions](#module\_lambda\_edge\_functions) | cloudposse/config/yaml//modules/deepmerge | 1.0.2 |
 | <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 1.1.1 |
@@ -301,4 +300,3 @@ components:
 
 
 [<img src="https://cloudposse.com/logo-300x69.svg" height="32" align="right"/>](https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-spa-s3-cloudfront&utm_content=)
-

--- a/src/README.md
+++ b/src/README.md
@@ -147,6 +147,7 @@ components:
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0, < 6.0.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 2.0.0, < 3.0.0 |
 
 ## Providers
 
@@ -160,16 +161,16 @@ components:
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_acm_request_certificate"></a> [acm\_request\_certificate](#module\_acm\_request\_certificate) | cloudposse/acm-request-certificate/aws | 0.18.0 |
-| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_dns_delegated"></a> [dns\_delegated](#module\_dns\_delegated) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_gha_role_name"></a> [gha\_role\_name](#module\_gha\_role\_name) | cloudposse/label/null | 0.25.0 |
-| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
+| <a name="module_github_runners"></a> [github\_runners](#module\_github\_runners) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 | <a name="module_lambda_edge"></a> [lambda\_edge](#module\_lambda\_edge) | cloudposse/cloudfront-s3-cdn/aws//modules/lambda@edge | 1.1.1 |
 | <a name="module_lambda_edge_functions"></a> [lambda\_edge\_functions](#module\_lambda\_edge\_functions) | cloudposse/config/yaml//modules/deepmerge | 1.0.2 |
 | <a name="module_spa_web"></a> [spa\_web](#module\_spa\_web) | cloudposse/cloudfront-s3-cdn/aws | 1.1.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.4.0 |
-| <a name="module_waf"></a> [waf](#module\_waf) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
+| <a name="module_waf"></a> [waf](#module\_waf) | cloudposse/stack-config/yaml//modules/remote-state | 2.0.0 |
 
 ## Resources
 

--- a/src/github-actions-iam-role.mixin.tf
+++ b/src/github-actions-iam-role.mixin.tf
@@ -58,7 +58,7 @@ module "github_oidc_provider" {
   count = local.github_actions_iam_role_enabled ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "2.0.0"
+  version = "1.8.0"
 
   component     = "github-oidc-provider"
   environment   = "gbl"

--- a/src/github-actions-iam-role.mixin.tf
+++ b/src/github-actions-iam-role.mixin.tf
@@ -58,7 +58,7 @@ module "github_oidc_provider" {
   count = local.github_actions_iam_role_enabled ? 1 : 0
 
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component     = "github-oidc-provider"
   environment   = "gbl"

--- a/src/github-actions-iam-role.mixin.tf
+++ b/src/github-actions-iam-role.mixin.tf
@@ -1,7 +1,6 @@
 # This mixin requires that a local variable named `github_actions_iam_policy` be defined
 # and its value to be a JSON IAM Policy Document defining the permissions for the role.
-# It also requires that the `github-oidc-provider` has been previously installed and the
-# `github-assume-role-policy.mixin.tf` has been added to `account-map/modules/team-assume-role-policy`.
+# It also requires that the `github-oidc-provider` has been previously installed.
 
 variable "github_actions_iam_role_enabled" {
   type        = bool
@@ -30,6 +29,19 @@ variable "github_actions_iam_role_attributes" {
 
 locals {
   github_actions_iam_role_enabled = local.enabled && var.github_actions_iam_role_enabled && length(var.github_actions_allowed_repos) > 0
+  trusted_github_repos_regexp     = "^(?:(?P<org>[^://]*)\\/)?(?P<repo>[^://]*):?(?P<constraint>.*)?$"
+  trusted_github_repos_sub = [
+    for repo in var.github_actions_allowed_repos : regex(local.trusted_github_repos_regexp, repo)
+  ]
+  github_repos_sub = [
+    for repo in local.trusted_github_repos_sub : (
+      repo["constraint"] == "" ?
+      format("repo:%s/%s:*", coalesce(repo["org"], "cloudposse"), repo["repo"]) :
+      startswith(repo["constraint"], "ref:") || startswith(repo["constraint"], "environment:") ?
+      format("repo:%s/%s:%s", coalesce(repo["org"], "cloudposse"), repo["repo"], repo["constraint"]) :
+      format("repo:%s/%s:ref:refs/heads/%s", coalesce(repo["org"], "cloudposse"), repo["repo"], repo["constraint"])
+    )
+  ]
 }
 
 module "gha_role_name" {
@@ -42,18 +54,58 @@ module "gha_role_name" {
   context = module.this.context
 }
 
-module "gha_assume_role" {
-  source = "../account-map/modules/team-assume-role-policy"
+module "github_oidc_provider" {
+  count = local.github_actions_iam_role_enabled ? 1 : 0
 
-  trusted_github_repos = var.github_actions_allowed_repos
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "2.0.0"
+
+  component     = "github-oidc-provider"
+  environment   = "gbl"
+  privileged    = false
+  ignore_errors = true
+
+  defaults = {
+    oidc_provider_arn = ""
+  }
 
   context = module.gha_role_name.context
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  count = local.github_actions_iam_role_enabled ? 1 : 0
+
+  statement {
+    sid = "OidcProviderAssume"
+    actions = [
+      "sts:AssumeRoleWithWebIdentity",
+      "sts:SetSourceIdentity",
+      "sts:TagSession",
+    ]
+
+    principals {
+      type        = "Federated"
+      identifiers = [one(module.github_oidc_provider[*].outputs.oidc_provider_arn)]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = local.github_repos_sub
+    }
+  }
 }
 
 resource "aws_iam_role" "github_actions" {
   count              = local.github_actions_iam_role_enabled ? 1 : 0
   name               = module.gha_role_name.id
-  assume_role_policy = module.gha_assume_role.github_assume_role_policy
+  assume_role_policy = one(data.aws_iam_policy_document.github_actions_assume_role[*].json)
 
   inline_policy {
     name   = module.gha_role_name.id

--- a/src/provider-other-regions.tf
+++ b/src/provider-other-regions.tf
@@ -2,17 +2,6 @@ provider "aws" {
   region = local.failover_region # if var.failover_s3_region is not set, this will fall back on var.region
 
   alias = "failover"
-
-  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
-  profile = module.iam_roles.terraform_profile_name
-
-  dynamic "assume_role" {
-    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
-    for_each = compact([module.iam_roles.terraform_role_arn])
-    content {
-      role_arn = assume_role.value
-    }
-  }
 }
 
 # For cloudfront, the acm has to be created in us-east-1 or it will not work
@@ -20,15 +9,4 @@ provider "aws" {
   region = "us-east-1"
 
   alias = "us-east-1"
-
-  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
-  profile = module.iam_roles.terraform_profile_name
-
-  dynamic "assume_role" {
-    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
-    for_each = compact([module.iam_roles.terraform_role_arn])
-    content {
-      role_arn = assume_role.value
-    }
-  }
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,19 +1,3 @@
 provider "aws" {
   region = var.region
-
-  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
-  profile = module.iam_roles.terraform_profile_name
-
-  dynamic "assume_role" {
-    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
-    for_each = compact([module.iam_roles.terraform_role_arn])
-    content {
-      role_arn = assume_role.value
-    }
-  }
-}
-
-module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
-  context = module.this.context
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,6 +1,6 @@
 module "waf" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   bypass      = !local.aws_waf_enabled
   component   = var.cloudfront_aws_waf_component_name
@@ -18,7 +18,7 @@ module "waf" {
 
 module "dns_delegated" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   component   = "dns-delegated"
   environment = var.dns_delegated_environment_name
@@ -28,7 +28,7 @@ module "dns_delegated" {
 
 module "github_runners" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "1.8.0"
+  version = "2.0.0"
 
   bypass      = !local.github_runners_enabled
   component   = var.github_runners_component_name

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.9.0, < 6.0.0"
     }
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 2.0.0, < 3.0.0"
+    }
   }
 }


### PR DESCRIPTION
## What

- use ambient AWS credentials for the default, failover, and us-east-1 providers
- remove the local `../account-map/modules/iam-roles` dependency
- preserve the optional GitHub Actions deployment role by building its GitHub OIDC trust policy directly
- remove the local `../account-map/modules/team-assume-role-policy` dependency
- update generated module tables and contributor guidance

## Why

The component is published and vendored independently, but two module sources assume a sibling `account-map` component exists. A consumer that vendors only `aws-spa-s3-cloudfront` fails during `terraform init` before planning:

```text
Unable to evaluate directory symlink: lstat ../account-map: no such file or directory
```

Credential and role assumption should be configured by the execution environment. The GitHub Actions role only needs the GitHub OIDC provider and repository-subject constraints, so its trust policy does not require the generic account-map role machinery.

The OIDC audience and subject matching behavior is preserved, including organization-qualified repositories, branch constraints, `ref:` constraints, and `environment:` constraints.

## Validation

- `terraform -chdir=src fmt -check`
- `git diff --check`
- confirmed no `account-map` or `module.iam_roles` references remain under `src/`
- direct adversarial review approved the provider and OIDC trust-policy changes

Full dependency initialization was attempted with both Terraform and OpenTofu, but registry downloads did not complete in the local execution environment. Upstream CI remains required before this is ready to merge.

## Migration note

Provider authentication now comes from ambient AWS credentials. Consumers that relied on the component to select a profile or assume a Terraform role must move that configuration to their runner, Atmos auth wrapper, or surrounding execution environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional GitHub Actions OIDC provider setup and updated role-assumption policy generation based on allowed repositories and optional branch/environment constraints.

* **Documentation**
  * Clarified that AWS credentials/role assumption must be configured in the runner or surrounding execution environment (ambient credentials).
  * Regenerated README materials and Terraform docs to reflect the current providers/modules/resources and added an assume-role policy data source entry.

* **Bug Fixes**
  * Removed deprecated role-assumption provider guidance and outdated references to previously documented role-assumption components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->